### PR TITLE
organise rules into individual snakefiles - resources directives and …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ raw_reads/
 trimmed/
 sub/
 interleave/
-
+.snakemake/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # Assembly_pipeline_feb
+
+Do a dry-run:
+```bash
+snakemake -np
+```

--- a/Snakefile
+++ b/Snakefile
@@ -1,0 +1,24 @@
+import os
+import pandas as pd
+
+configfile: "data/config.yaml"
+sample_data = pd.read_table(config["samples"], sep="\t").set_index("ID", drop=False)
+
+Assembler = ["norgal", "getorganelle", "mitoflex", "novoplasty", "mitobim"] #, "MitoFlex", "GetOrganelle", "Novoplasty", "MITObim"]
+sub = [10000000, 20000000]
+
+include: "rules/functions.smk"
+include: "rules/download.smk"
+include: "rules/trimming.smk"
+include: "rules/subsample.smk"
+include: "rules/norgal.smk"
+include: "rules/getorganelle.smk"
+include: "rules/mitoflex.smk"
+include: "rules/novoplasty.smk"
+include: "rules/mitobim.smk"
+include: "rules/eval.smk"
+
+localrules: all, setup_mitoflex_db, NOVOconfig, quast
+rule all:
+	input:
+		expand(rules.quast.output, id=IDS, sub=sub, assembler=Assembler)

--- a/rules/download.smk
+++ b/rules/download.smk
@@ -1,0 +1,22 @@
+rule fastqdump:
+	params:
+		accession = get_accession
+	output:
+		f = "raw_mt_reads/{id}_1.fastq.gz",
+		r = "raw_mt_reads/{id}_2.fastq.gz"
+#	resources:
+#		qos="normal_0064",
+#		partition="mem_0064",
+#		mem="10G",
+#		name="fastq-dump",
+#		nnode="-N 1"
+	conda: "envs/sra-tools.yml"
+	threads: 2
+	shadow: "minimal"
+	shell:
+		"""
+		prefetch --max-size 1024000000 {params.accession}
+		fastq-dump --split-files --gzip --defline-seq '@$ac-$sn/$ri' {params.accession}
+		mv {params.accession}_1.fastq.gz {output.f}
+		mv {params.accession}_2.fastq.gz {output.r}
+		"""

--- a/rules/eval.smk
+++ b/rules/eval.smk
@@ -1,0 +1,25 @@
+rule quast:
+    input:
+        expand("assemblies/{assembler}/{id}/{sub}/{assembler}.ok", id=IDS, sub=sub, assembler=Assembler)
+	
+#        norgal = expand("assemblies/{assembler}/{id}/{sub}/{id}_{assembler}", sub=sub, id = IDS,  assembler = Assembler[0]),
+##        norgal = rules.norgal.output,
+#        MitoFlex = expand("assemblies/{assembler}/{id}/{sub}/{id}.picked.fa", sub=sub, id = IDS, assembler = Assembler[1]),
+##        Mitoflex = rules.mitoflex.output.fasta,
+#        GetOrganelle = expand("assemblies/{assembler}/{id}/{sub}/{id}.getorganelle.final.fasta", sub=sub, id = IDS, assembler = Assembler[2]),
+##        GetOrganelle = rules.get_organelle.output,
+#        Novoplasty = expand("assemblies/{assembler}/{id}/{sub}/Circularized_assembly_1_{id}_{sub}_novoplasty.fasta", sub=sub, id = IDS, assembler = Assembler[3]),
+##        Novoplasty = rules.NOVOplasty.output,
+#        MITObim = expand("assemblies/{assembler}/{id}/{sub}/{id}_{assembler}_coxI.fasta", sub=sub, id = IDS, assembler = Assembler[4])
+##        MITObim = rules.MITObim.output
+    output:
+        "QUAST/report.tsv"
+    params:
+        outdir = "QUAST/",
+    conda:
+        "envs/quast.yml"
+    threads: 1
+    shell:
+        """
+        quast -o {params.outdir} {input}
+        """

--- a/rules/functions.smk
+++ b/rules/functions.smk
@@ -1,0 +1,16 @@
+import os
+import pandas as pd
+
+IDS = sample_data.index.values.tolist()
+def get_accession(wildcards):
+	return sample_data.loc[(wildcards.id), ["SRA"]].dropna().values[0]
+
+def get_seed(wildcards):
+        return sample_data.loc[(wildcards.id), ["seed"]].dropna().values[0]
+
+def get_clade(wildcards):
+        return sample_data.loc[(wildcards.id), ["Clade"]].dropna().values[0]
+
+def get_code(wildcards):
+        return sample_data.loc[(wildcards.id), ["Code"]].dropna().values[0]
+

--- a/rules/getorganelle.smk
+++ b/rules/getorganelle.smk
@@ -1,0 +1,46 @@
+##rule download_GO_database:
+##    output:
+##       "get_organelle.db.ok"
+##    conda:
+##       "envs/getorganelle.yml" 
+##    threads: 1
+##    shell:
+##       """
+##       get_organelle_config.py --clean
+##       get_organelle_config.py -a animal_mt
+##       touch {output}
+##       """
+#
+#
+rule get_organelle:
+    input:
+#        ok = rules.download_GO_database.output,
+        f = rules.subsample.output.f,
+        r = rules.subsample.output.r
+    output:
+#        fasta = "assemblies/{assembler}/{id}/{sub}/{id}.getorganelle.final.fasta",
+        ok = "assemblies/getorganelle/{id}/{sub}/getorganelle.ok"
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="getorganelle",
+#        nnode="-N 1"
+    params:
+        outdir = "assemblies/getorganelle/{id}/{sub}",
+        seed = get_seed
+    singularity:"docker://reslp/getorganelle:1.7.1"
+#    conda:
+#        "envs/getorganelle.yml"
+    log:
+        "assemblies/getorganelle/{id}/{sub}/getorganelle_log_{id}_{sub}.log"
+    threads: 24
+    shell:
+        """
+        get_organelle_from_reads.py -1 {input.f} -2 {input.r} -o {params.outdir} -F animal_mt -t {threads} -R 10 -s {params.seed}
+        #get the path to the one fasta file in the output directory (assumes there is only one)
+        final_fasta=$(ls $(pwd)/{params.outdir}/*.fasta)
+        #create a symbolic link between the final fasta file and the output file as specified in the rule above
+        touch {output.ok}
+        """
+#        ln -s $final_fasta $(pwd)/{output.fasta}

--- a/rules/mitobim.smk
+++ b/rules/mitobim.smk
@@ -1,0 +1,47 @@
+rule interleave:
+    input:
+        f = rules.subsample.output.f,
+        r = rules.subsample.output.r,
+#    resources:
+#        qos="normal_0064",
+#        partition="mem_0064",
+#        mem="10G",
+#        name="interleave",
+#        nnode="-N 1"
+    threads: 2
+    output:
+        "interleave/{sub}/{id}_interleaved.fastq"
+    conda:
+        "envs/bbmap.yml"
+    shell:
+        """
+	reformat.sh in1={input.f} in2={input.r} out={output}
+	"""
+
+rule MITObim:
+    input:
+        rules.interleave.output
+    output:
+#        fasta = "assemblies/{assembler}/{id}/{sub}/{id}_{assembler}_coxI.fasta",
+        ok = "assemblies/mitobim/{id}/{sub}/mitobim.ok"
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="MITObim",
+#        nnode="-N 1"
+    params:
+        id = "{id}",
+        seed = get_seed,
+        wd = os.getcwd()
+    log: "assemblies/mitobim/{id}/{sub}/{id}_mitobim_{sub}.log"
+    singularity:
+        "docker://chrishah/mitobim:v.1.9.1"
+    shadow: "shallow"
+    threads: 10
+    shell:
+        """
+        MITObim.pl -sample {params.id} -ref {params.id}_coxI -readpool {input} --quick {params.seed} -end 100 --paired --clean --NFS_warn_only &> {log}
+        touch {output.ok}       
+        """ 
+#        cp $(find ./ -name "*noIUPAC.fasta") {output.fasta}

--- a/rules/mitoflex.smk
+++ b/rules/mitoflex.smk
@@ -1,0 +1,54 @@
+rule setup_mitoflex_db:
+    output: 
+        ok = "bin/MitoFlex/mitoflex.db.status.ok",
+    params:
+        wd = os.getcwd(),
+    singularity: "docker://samlmg/mitoflex:v0.2.9"
+    threads: 1
+    shell:
+        """
+        cp -pfr /MitoFlex/* bin/MitoFlex/
+        cp bin/ncbi_custom.py bin/MitoFlex/ncbi.py
+        cd bin/MitoFlex/
+        export HOME=$(pwd)
+        echo $HOME
+        ./ncbi.py n
+        touch {params.wd}/{output.ok}
+        """
+
+rule mitoflex:
+    input:
+        f = rules.subsample.output.f,
+        r = rules.subsample.output.r,
+        db = rules.setup_mitoflex_db.output
+    output:
+#        fasta = "assemblies/{assembler}/{id}/{sub}/{id}.picked.fa",
+        ok = "assemblies/mitoflex/{id}/{sub}/mitoflex.ok",
+#	run = directory("assemblies/{assembler}/{id}/{sub}/MitoFlex")
+    params:
+        wd = os.getcwd(),
+	outdir = "assemblies/mitoflex/{id}/{sub}",
+        id = "{id}",
+        clade = get_clade,
+        genetic_code = get_code 
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        ntasks="24",
+#        name="MitoFlex",
+#        nnode="-N 1",
+    log:
+        stdout = "assemblies/mitoflex/{id}/{sub}/stdout.txt",
+        stderr = "assemblies/mitoflex/{id}/{sub}/stderr.txt"
+    threads: 24
+    singularity: "docker://samlmg/mitoflex:v0.2.9"
+#    shadow: "minimal"
+    shell:
+        """
+        cd {params.outdir}
+	export HOME="{params.wd}/bin/MitoFlex"
+        {params.wd}/bin/MitoFlex/MitoFlex.py all --workname MitoFlex --threads {threads} --insert-size 167 --fastq1 {params.wd}/{input.f} --fastq2 {params.wd}/{input.r} --genetic-code {params.genetic_code} --clade {params.clade} 1> {params.wd}/{log.stdout} 2> {params.wd}/{log.stderr} 
+        touch {params.wd}/{output.ok}
+        """
+#        cp $(find ./ -name "*.picked.fa") {output.fasta}

--- a/rules/norgal.smk
+++ b/rules/norgal.smk
@@ -1,0 +1,21 @@
+rule norgal:
+    input:
+        f = rules.subsample.output.f,
+        r = rules.subsample.output.r
+    output:
+#        directory("assemblies/{assembler}/{id}/{sub}/{id}_{assembler}"),
+        ok = "assemblies/norgal/{id}/{sub}/norgal.ok"
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="norgal",
+#        nnode="-N 1"
+    threads: 24
+    shell:
+        """
+        module load intel/18 intel-mkl/2018 python/2.7 numpy/1.12.0 matplotlib/2.2.2
+        export PATH="/home/lv71312/leeming/mt_assembly/norgal/binaries/linux:$PATH"        
+        python /home/lv71312/leeming/mt_assembly/norgal/norgal.py -i {input.f} {input.r} -o {output} --blast -t {threads}
+        touch {output}
+        """

--- a/rules/novoplasty.smk
+++ b/rules/novoplasty.smk
@@ -1,0 +1,47 @@
+rule NOVOconfig:
+    input:
+        "bin/NOVOconfig.txt"
+    output:
+        "assemblies/novoplasty/{id}/{sub}/NOVOconfig_{id}_{sub}.txt"
+    params:
+        project_name = "{id}",
+        seed = get_seed,
+        log = "assemblies/novoplasty/{id}/{sub}/NOVOconfig_{id}_{sub}_log.txt",
+        f = rules.subsample.output.f,
+        r = rules.subsample.output.r
+    shell:
+        """
+        cp {input} {output}
+        sed -i 's?^Project name.*?Project name = {params.project_name}?g' {output}
+        sed -i 's?^Seed Input.*?Seed Input = {params.seed}?g' {output}
+        sed -i 's?^Extended log.*?Extended log = {params.log}?g' {output}
+        sed -i 's?^Forward reads.*?Forward reads = {params.f}?g' {output}
+        sed -i 's?^Reverse reads.*?Reverse reads = {params.r}?g' {output}
+        """
+
+rule NOVOplasty:
+    input:
+       config = rules.NOVOconfig.output,
+       ok = rules.subsample.output.f
+    output: 
+#       fasta = "assemblies/{assembler}/{id}/{sub}/Circularized_assembly_1_{id}_{sub}_novoplasty.fasta",
+       ok = "assemblies/novoplasty/{id}/{sub}/novoplasty.ok"
+    params:
+       outdir = "assemblies/novoplasty/{id}/{sub}"
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="NOVOplasty",
+#        nnode="-N 1"
+    log: "assemblies/novoplasty/{id}/{sub}/{id}_novoplasty_{sub}.log"
+    threads: 24
+    shadow: "shallow"
+    conda:
+       "envs/novoplasty.yml"
+    shell:
+       """
+       scripts/NOVOPlasty4.2.1.pl -c {input.config}
+       cp $(find ./ -name "*.fasta") {params.outdir}
+       touch {output.ok}
+       """

--- a/rules/subsample.smk
+++ b/rules/subsample.smk
@@ -1,0 +1,23 @@
+rule subsample:
+    input:
+        f = rules.trimmomatic.output.fout,
+        r = rules.trimmomatic.output.rout
+    output:
+        f = "sub/{sub}/{id}_1.fastq.gz",
+        r = "sub/{sub}/{id}_2.fastq.gz"
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="subsample",
+#        nnode="-N 1"
+    params: 
+        seed=553353,
+    threads: 24
+    conda:
+        "envs/seqtk.yml"
+    shell:
+        """
+        seqtk sample -s{params.seed} {input.f} {wildcards.sub} | gzip > {output.f}
+        seqtk sample -s{params.seed} {input.r} {wildcards.sub} | gzip > {output.r}
+        """

--- a/rules/trimming.smk
+++ b/rules/trimming.smk
@@ -1,0 +1,24 @@
+rule trimmomatic:
+    input:
+        f = rules.fastqdump.output.f,
+        r = rules.fastqdump.output.r
+#    resources:
+#        qos="normal_binf -C binf",
+#        partition="binf",
+#        mem="100G",
+#        name="trimmomatic",
+#        nnode="-N 1"
+    output:
+        fout = "trimmed/{id}_1P_trim.fastq.gz",
+        funp = "trimmed/{id}_1P_unpaired.fastq.gz",
+        rout = "trimmed/{id}_2P_trim.fastq.gz",
+        runp = "trimmed/{id}_2P_unpaired.fastq.gz",
+        ok = "trimmed/trim_{id}.ok"
+    threads: 24
+    conda:
+        "envs/trimmomatic.yml"
+    shell:
+        """
+        trimmomatic PE -threads {threads} {input.f} {input.r} {output.fout} {output.funp} {output.rout} {output.runp} ILLUMINACLIP:adapterseq/Adapters_PE.fa:2:30:10: LEADING:30 TRAILING:30 SLIDINGWINDOW:4:15 MINLEN:80
+        touch {output.ok}
+        """


### PR DESCRIPTION
…some rule outputs still need some work but dry-run `snakemake -np` works for me. Which assemblers are executed is now controlled via the `Assembler` list currently in the Snakefile. This should be moved to a config yaml file. 