### PR TITLE
Move towards cluster independence

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "bin/immediate_submit"]
+	path = bin/immediate_submit
+	url = https://github.com/reslp/immediate-submit

--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ Do a dry-run:
 ```bash
 snakemake -np
 ```
+
+To clone this repository incl. the immediate-submit submodule:
+
+```
+git clone --recursive https://github.com/SamLMG/Assembly_pipeline_feb.git
+```

--- a/README.md
+++ b/README.md
@@ -10,3 +10,10 @@ To clone this repository incl. the immediate-submit submodule:
 ```
 git clone --recursive https://github.com/SamLMG/Assembly_pipeline_feb.git
 ```
+
+Commands to run the pipeline using the assembly script:
+```
+./assembly -t slurm -c data/cluster-config-VSC3-SLURM.yaml.template
+./assembly -t slurm -c data/cluster-config-SLURM.yaml.template
+```
+

--- a/assembly
+++ b/assembly
@@ -1,0 +1,77 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+        echo "Welcome to phylociraptor. Your are using Git commit: $commit"
+        echo
+        echo "Usage: $0 [-v] [-t <submission_system>] [-c <cluster_config_file>] [-s <snakemke_args>]"
+        echo
+        echo "Options:"
+        echo "  -t <submission_system> Specify available submission system. Options: sge, slurm, torque, serial (no submission system)."
+        echo "  -c <cluster_config_file> Path to cluster config file in YAML format (mandatory). "
+        echo "  -s <snakemake_args> Additional arguments passed on to the snakemake command (optional)."
+        echo "  -i \"<singularity_args>\" Additional arguments passed on to singularity (optional)."
+	echo
+	echo "  --dry Invokes a dry-run. Corresponds to: snakemake -n"
+	#echo "  --report This creates an overview report of the run."
+	#echo "  --setup Will download the genomes and prepare the pipeline to run."
+	#echo "  --remove Resets the pipeline. Will delete all results, logs and checkpoints."
+	echo
+        1>&2; exit 1; }
+
+version() {
+        echo "$0 Git commit: $commit"
+        exit 0
+}
+CLUSTER=""
+CLUSTER_CONFIg=""
+SETUP=""
+REPORT=""
+DRY=""
+NJOBS="10001"
+commit=$(git rev-parse --short HEAD)
+STDSMARGS="--notemp --latency-wait 600"
+
+while getopts ":vt:c:s:m:i:-:" option;
+        do
+                case "${option}"
+                in
+                        v) version;;
+                        t) CLUSTER=${OPTARG};;
+                        c) CLUSTER_CONFIG=${OPTARG};;
+                        s) SM_ARGS=${OPTARG};;
+                        i) SI_ARGS=${OPTARG};;
+                        m) RUNMODE=${OPTARG};;
+			-) LONG_OPTARG="${OPTARG#*}"
+				case $OPTARG in
+					add-genomes) ADD="TRUE";;
+					setup) SETUP="TRUE" ;;
+					remove) REMOVE="TRUE" ;;
+					report) REPORT="TRUE" ;;
+					dry) DRY="-n" ;;
+					'' ) break ;;
+					*) echo "Illegal option --$OPTARG" >&2; usage; exit 2 ;;
+				esac ;;	
+                        *) echo "Illegal option --$OPTARG" >&2; usage;;
+                        ?) echo "Illegal option --$OPTARG" >&2 usage;;
+                esac
+        done
+#SM_ARGS="--quiet"
+if [ $OPTIND -eq 1 ]; then usage; fi
+
+if [[ $CLUSTER == "slurm" ]]; then
+          export CONDA_PKGS_DIRS="$(pwd)/.conda_pkg_tmp"
+          mkdir -p .conda_pkg_tmp
+          snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster '$(pwd)/bin/immediate_submit/immediate_submit.py {dependencies} slurm' --immediate-submit $STDSMARGS $SM_ARGS $DRY
+        unset CONDA_PKGS_DIRS
+  elif [[ $CLUSTER == "sge" ]]; then
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' sge" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+  elif [[ $CLUSTER == "torque" ]]; then
+        snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" --jobs $NJOBS --cluster-config $CLUSTER_CONFIG --cluster "$(pwd)/bin/immediate_submit/immediate_submit.py '{dependencies}' torque" --immediate-submit $STDSMARGS $SM_ARGS $DRY
+  elif [[ $CLUSTER == "serial" ]]; then
+    snakemake --use-conda --use-singularity --singularity-args "-B $(pwd)/.usr_tmp:/usertmp $SI_ARGS" $STDSMARGS $SM_ARGS $DRY
+  else
+          echo "Submission system not recognized"
+          exit 1
+  fi

--- a/data/cluster-config-SLURM.yaml.template
+++ b/data/cluster-config-SLURM.yaml.template
@@ -1,0 +1,28 @@
+# this is the cluster config file template for SLURM clusters
+# you can change them according to your own cluster settings.
+# please use the long options for individual flags (eg. use --ntasks instead of -n)
+__default__:
+   time: "72:00:00"
+   ntasks: 1
+   job-name: DEF 
+   mem: 4G
+   partition: mem_0096 
+   qos: mem_0096
+   output: $(pwd)/log/slurm-%j.out
+   error: $(pwd)/log/slurm-%j.err
+fastqdump:
+   job-name: FASTQD
+   mem: 10G
+   ntasks: 4
+norgal:
+   job-name: NORGAL
+   ntasks: 16
+   mem: 90G
+quast:
+   job-name: QUAST
+subsample:
+   job-name: SUB
+trimmomatic:
+   job-name: TRIM
+   ntasks: 16
+   mem: 40G

--- a/data/cluster-config-VSC3-SLURM.yaml.template
+++ b/data/cluster-config-VSC3-SLURM.yaml.template
@@ -6,8 +6,8 @@ __default__:
    ntasks: 1
    job-name: DEF 
    mem: 4G
-   partition: mem_0096 
-   qos: mem_0096
+   partition: mem_0064 
+   qos: normal_0064
    output: $(pwd)/log/slurm-%j.out
    error: $(pwd)/log/slurm-%j.err
 fastqdump:
@@ -15,40 +15,53 @@ fastqdump:
    mem: 10G
    ntasks: 2
 get_organelle:
-   mem: 90G
+   qos: "normal_binf -C binf"
+   partition: binf
+   mem: 100G
    job-name: GETORG
    ntasks: 24
 setup_mitoflex_db:
    job-name: sMFDB
 mitoflex:
    job-name: MITOF
+   partition: binf
+   qos: "normal_binf -C binf"
    ntasks: 24
-   mem: 90G
+   mem: 100G
 norgal:
    job-name: NORGAL
    partition: binf
+   qos: "normal_binf -C binf"
    ntasks: 24
-   mem: 90G
+   mem: 100G
 NOVOconfig:
    job-name: NOVOC
 NOVOplasty:
    job-name: NOVOP
-   mem: 90G
+   partition: binf
+   qos: "normal_binf -C binf"
+   mem: 100G
 quast:
    job-name: QUAST
 subsample:
    job-name: SUB
-   mem: 90G
+   partition: binf
+   qos: "normal_binf -C binf"
+   mem: 100G
    ntasks: 24
 trimmomatic:
    job-name: TRIM
+   partition: binf
+   qos: "normal_binf -C binf"
    ntasks: 24
-   mem: 90G
+   mem: 100G
 interleave:
    job-name: INTER
    mem: 10G
    ntasks: 2
 MITObim:
+   qos: normal_0128
+   partition: mem_0128
    mem: 60G
    ntasks: 10
   


### PR DESCRIPTION
I made several additions to help make the pipeline independent of the cluster setup. This PR should not interfere with the current setup of the pipeline (only the README file is changed). I have not actually tested this thoroughly yet, but the created submission commands look fine.

These are the main changes:
- Add the immediate_submit.py script. This is added as a git submodule (hence the .gitmodules file). This script has its own repository and changes to it will automatically be pull together with the pipelines repository. See the note on how to clone in the readme file.
- added Cluster Configuration files for SLURM clusters (currently setup to fit VSC4) and another one for VSC3.
- Some small additions to the README file.

Probably this will require additional changes, once we actually test to submit jobs with the new assembly script.